### PR TITLE
Added feature of random DateOnly and TimeOnly

### DIFF
--- a/Source/Bogus.Tests/Bogus.Tests.csproj
+++ b/Source/Bogus.Tests/Bogus.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net471;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net471;netcoreapp2.1;netcoreapp3.1;net60</TargetFrameworks>
     <AssemblyOriginatorKeyFile>
     </AssemblyOriginatorKeyFile>
     <SignAssembly>false</SignAssembly>

--- a/Source/Bogus.Tests/DataSetTests/DateTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/DateTest.cs
@@ -10,7 +10,7 @@ namespace Bogus.Tests.DataSetTests
    {
       public DateTest()
       {
-         date = new Date();         
+         date = new Date();
       }
 
       private readonly Date date;
@@ -432,7 +432,7 @@ namespace Bogus.Tests.DataSetTests
             .BeOnOrBefore(end);
       }
 
-	  [Fact]
+      [Fact]
       public void can_get_dateOnly_recently_within_the_year()
       {
          var start = DateTime.Now;
@@ -442,7 +442,6 @@ namespace Bogus.Tests.DataSetTests
             .And
             .BeOnOrAfter(start.AddDays(-1));
       }
-
 
       [Fact]
       public void can_get_random_timeOnly_between_two_dates()

--- a/Source/Bogus.Tests/DataSetTests/DateTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/DateTest.cs
@@ -10,7 +10,7 @@ namespace Bogus.Tests.DataSetTests
    {
       public DateTest()
       {
-         date = new Date();
+         date = new Date();         
       }
 
       private readonly Date date;
@@ -352,5 +352,139 @@ namespace Bogus.Tests.DataSetTests
       {
          date.TimeZoneString().Should().Be("Asia/Yerevan");
       }
+
+#if NET6_0
+      [Fact]
+      public void can_get_dateOnly_in_past()
+      {
+         var starting = DateTime.Parse("9/11/2021 00:00:00");
+         var startingDateOnly = DateOnly.FromDateTime(starting);
+         var resultantDateTime = date.PastDateOnly(refDateOnly: startingDateOnly).ToDateTime(default);
+         resultantDateTime.Should()
+            .BeOnOrBefore(starting)
+            .And
+            .BeOnOrAfter(starting.AddYears(-1));
+      }
+
+      [Fact]
+      public void can_get_dateOnly_in_past_with_custom_options()
+      {
+         var starting = DateTime.Parse("9/11/2021 00:00:00", CultureInfo.InvariantCulture);
+         var startingDateOnly = DateOnly.FromDateTime(starting);
+         var resultantDateTime = date.PastDateOnly(refDateOnly: startingDateOnly, yearsToGoBack: 5).ToDateTime(default);
+         resultantDateTime.Should()
+            .BeOnOrBefore(starting)
+            .And
+            .BeOnOrAfter(starting.AddYears(-5));
+      }
+
+      [Fact]
+      public void get_a_dateOnly_that_will_happen_soon()
+      {
+         var now = DateTime.Now;
+         date.SoonDateOnly(3).ToDateTime(default).Should().BeAfter(now).And.BeBefore(now.AddDays(3));
+      }
+
+      [Fact]
+      public void can_get_dateOnly_in_future()
+      {
+         var starting = DateTime.Parse("9/11/2021 00:00:00");
+         var startingDateOnly = DateOnly.FromDateTime(starting);
+         var resultantDateTime = date.FutureDateOnly(refDateOnly: startingDateOnly).ToDateTime(default);
+         resultantDateTime.Should()
+            .BeOnOrBefore(starting.AddYears(1))
+            .And
+            .BeOnOrAfter(starting);
+      }
+
+      [Fact]
+      public void can_get_dateOnly_in_future_with_options()
+      {
+         var starting = DateTime.Parse("9/11/2021 00:00:00", CultureInfo.InvariantCulture);
+         var startingDateOnly = DateOnly.FromDateTime(starting);
+         var resultantDateTime = date.FutureDateOnly(refDateOnly: startingDateOnly, yearsToGoForward: 5).ToDateTime(default);
+         resultantDateTime.Should()
+            .BeOnOrBefore(starting.AddYears(5))
+            .And
+            .BeOnOrAfter(starting);
+      }
+
+      [Fact]
+      public void can_get_random_dateOnly_between_two_dates()
+      {
+         var start = DateTime.Parse("08/08/2021 00:00:00", CultureInfo.InvariantCulture);
+         var end = DateTime.Parse("12/12/2021 00:00:00", CultureInfo.InvariantCulture);
+
+         var startDateOnly = DateOnly.FromDateTime(start);
+         var endDateOnly = DateOnly.FromDateTime(end);
+
+         date.BetweenDateOnly(startDateOnly, endDateOnly).ToDateTime(default)
+            .Should()
+            .BeOnOrAfter(start)
+            .And
+            .BeOnOrBefore(end);
+
+         //and reverse...
+         date.BetweenDateOnly(endDateOnly, startDateOnly).ToDateTime(default)
+            .Should()
+            .BeOnOrAfter(start)
+            .And
+            .BeOnOrBefore(end);
+      }
+
+	  [Fact]
+      public void can_get_dateOnly_recently_within_the_year()
+      {
+         var start = DateTime.Now;
+         date.RecentDateOnly().ToDateTime(default)
+            .Should()
+            .BeOnOrBefore(start)
+            .And
+            .BeOnOrAfter(start.AddDays(-1));
+      }
+
+
+      [Fact]
+      public void can_get_random_timeOnly_between_two_dates()
+      {
+         var start = DateTime.Parse("08/08/2021 00:00:00 AM", CultureInfo.InvariantCulture);
+         var end = DateTime.Parse("12/12/2021 10:00:00 PM", CultureInfo.InvariantCulture);
+
+         var startTimeOnly = TimeOnly.FromDateTime(start);
+         var endTimeOnly = TimeOnly.FromDateTime(end);
+
+         var betweenTime = date.BetweenTimeOnly(startTimeOnly, endTimeOnly);
+         betweenTime.IsBetween(startTimeOnly, endTimeOnly).Should().BeTrue();
+
+         //and reverse should be negative...
+         var reverseBetweenTime = date.BetweenTimeOnly(endTimeOnly, startTimeOnly);
+         reverseBetweenTime.IsBetween(endTimeOnly, startTimeOnly).Should().BeFalse();
+
+      }
+
+      [Fact]
+      public void can_get_a_timeOnly_that_will_happen_soon()
+      {
+         var now = DateTime.Now;
+         
+         var soonTimeSpan = date.SoonTimeOnly(5).ToTimeSpan();
+         var soonDateTime = now.Date+soonTimeSpan;
+
+         soonDateTime.Should().BeAfter(now).And.BeBefore(now.AddMinutes(5));
+
+      }
+
+      [Fact]
+      public void can_get_a_timeOnly_that_happened_in_past()
+      {
+         var now = DateTime.Now;
+         
+         var recentTimeStamp = date.RecentTimeOnly(5).ToTimeSpan();
+         var recentDateTime = now.Date+recentTimeStamp;
+
+         recentDateTime.Should().BeBefore(now).And.BeAfter(now.AddMinutes(-5));
+
+      }
+#endif
    }
 }

--- a/Source/Bogus.Tests/GitHubIssues/Issue132.cs
+++ b/Source/Bogus.Tests/GitHubIssues/Issue132.cs
@@ -60,7 +60,7 @@ namespace Bogus.Tests.GitHubIssues
             .Should().Be("fr");
       }
 
-
+#if !NET6_0
       [Fact]
       public void nb_NO_locale()
       {
@@ -84,7 +84,7 @@ namespace Bogus.Tests.GitHubIssues
             .ToBogusLocale()
             .Should().Be("nb_NO");
       }
-
+#endif
 
       [Fact]
       public void id_ID_locale()

--- a/Source/Bogus.Tests/README_Generator.cs
+++ b/Source/Bogus.Tests/README_Generator.cs
@@ -76,11 +76,11 @@ namespace Bogus.Tests
             if (call == "#ctor") continue;
 
             var r = new Record
-            {
-               Dataset = dataset,
-               Method = call,
-               Summary = summary
-            };
+               {
+                  Dataset = dataset,
+                  Method = call,
+                  Summary = summary
+               };
             list.Add(r);
          }
 
@@ -178,8 +178,8 @@ namespace Bogus.Tests
          var publicMethods = typeof(Randomizer)
             .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
             .Select(mi => new {dataset = mi.DeclaringType.Name, method = mi.Name});
-         //.GroupBy(g => g.dataset, u => u.method)
-         //.ToDictionary(g => g.Key);
+            //.GroupBy(g => g.dataset, u => u.method)
+            //.ToDictionary(g => g.Key);
 
          foreach (var g in all)
          {

--- a/Source/Bogus.Tests/README_Generator.cs
+++ b/Source/Bogus.Tests/README_Generator.cs
@@ -76,11 +76,11 @@ namespace Bogus.Tests
             if (call == "#ctor") continue;
 
             var r = new Record
-               {
-                  Dataset = dataset,
-                  Method = call,
-                  Summary = summary
-               };
+            {
+               Dataset = dataset,
+               Method = call,
+               Summary = summary
+            };
             list.Add(r);
          }
 
@@ -102,7 +102,7 @@ namespace Bogus.Tests
             if( !datasets.ContainsKey(g.Key) ) return; //check if it's accessible
             var methods = datasets[g.Key];
 
-            var distinctMethods = g.DistinctBy(u => u.Method);
+            var distinctMethods = MoreEnumerable.DistinctBy(g, u => u.Method);
 
             output.WriteLine("* **`" + g.Key + "`**");
             foreach( var m in distinctMethods )
@@ -178,16 +178,17 @@ namespace Bogus.Tests
          var publicMethods = typeof(Randomizer)
             .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
             .Select(mi => new {dataset = mi.DeclaringType.Name, method = mi.Name});
-            //.GroupBy(g => g.dataset, u => u.method)
-            //.ToDictionary(g => g.Key);
+         //.GroupBy(g => g.dataset, u => u.method)
+         //.ToDictionary(g => g.Key);
 
          foreach (var g in all)
          {
             //if (!datasets.ContainsKey(g.Key)) return; //check if it's accessible
-            var distinctMethods = g
+            var sortedMethods = g
                .OrderBy(x => x.Method)
-               .ThenBy(x => x.Summary.Length)
-               .DistinctBy(u => u.Method);
+               .ThenBy(x => x.Summary.Length);
+            var distinctMethods = MoreEnumerable.DistinctBy(sortedMethods, u => u.Method);
+
             //we need to do this ordering so we select the most
             //succinct description for any method overloads.
 

--- a/Source/Bogus/Bogus.csproj
+++ b/Source/Bogus/Bogus.csproj
@@ -5,7 +5,7 @@
     </PackageReleaseNotes>
     <Version>0.0.0-localbuild</Version>
     <Authors>Brian Chavez</Authors>
-    <TargetFrameworks>net40;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard1.3;netstandard2.0;net60</TargetFrameworks>
     <CodeAnalysisRuleSet>Bogus.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>

--- a/Source/Bogus/DataSets/Date.cs
+++ b/Source/Bogus/DataSets/Date.cs
@@ -263,5 +263,133 @@ namespace Bogus.DataSets
       {
          return GetRandomArrayItem("address", "time_zone");
       }
+#if NET6_0
+      /// <summary>
+      /// Get a <see cref="DateOnly"/> in the past between <paramref name="refDateOnly"/> and <paramref name="yearsToGoBack"/>.
+      /// </summary>
+      /// <param name="yearsToGoBack">Years to go back from <paramref name="refDateOnly"/>. Default is 1 year.</param>
+      /// <param name="refDateOnly">The only date to start calculations. Default is the only Date from <see cref="DateTime.Now"/>.</param>
+      public DateOnly PastDateOnly(int yearsToGoBack = 1, DateOnly? refDateOnly = null)
+      {
+         var dateTime = refDateOnly?.ToDateTime(default) ?? SystemClock();
+         
+         var dtTimePast = Past(yearsToGoBack, dateTime);
+         
+         return DateOnly.FromDateTime(dtTimePast);
+      }
+
+      /// <summary>
+      /// Get a <see cref="DateOnly"/> that will happen soon.
+      /// </summary>
+      /// <param name="days">A date no more than <paramref name="days"/> ahead.</param>
+      /// <param name="refDateOnly">The date to start calculations. Default is the only date from <see cref="DateTimeOffset.Now"/>.</param>
+      public DateOnly SoonDateOnly(int days = 1, DateOnly? refDateOnly = null)
+      {
+         var dateTime = refDateOnly?.ToDateTime(default) ?? SystemClock();
+
+         var dtTimePast = Soon(days, dateTime);
+
+         return DateOnly.FromDateTime(dtTimePast);
+      }
+
+      /// <summary>
+      /// Get a <see cref="DateOnly"/> in the future between <paramref name="refDateOnly"/> and <paramref name="yearsToGoForward"/>.
+      /// </summary>
+      /// <param name="yearsToGoForward">Years to go forward from <paramref name="refDateOnly"/>. Default is 1 year.</param>
+      /// <param name="refDateOnly">The only date to start calculations. Default is the only date from <see cref="DateTimeOffset.Now"/>.</param>
+      public DateOnly FutureDateOnly(int yearsToGoForward = 1, DateOnly? refDateOnly = null)
+      {
+         var dateTime = refDateOnly?.ToDateTime(default) ?? SystemClock();
+
+         var dtTimePast = Future(yearsToGoForward, dateTime);
+
+         return DateOnly.FromDateTime(dtTimePast);
+      }
+
+      /// <summary>
+      /// Get a random <see cref="DateOnly"/> between <paramref name="start"/> and <paramref name="end"/>.
+      /// </summary>
+      /// <param name="start">Start Date - The returned <seealso cref="DateOnly"/> is used from this parameter.</param>
+      /// <param name="end">End Date</param>
+      public DateOnly BetweenDateOnly(DateOnly start, DateOnly end)
+      {
+         var startDateTime = start.ToDateTime(default);
+         var endDateTime = end.ToDateTime(default);
+
+         var resultantDateTime = Between(startDateTime, endDateTime);
+
+         return DateOnly.FromDateTime(resultantDateTime);
+      }
+
+      /// <summary>
+      /// Get a random <see cref="DateOnly"/> within the last few days.
+      /// </summary>
+      /// <param name="days">Number of days to go back.</param>
+      /// <param name="refDateOnly">The date to start calculations. Default is the only date from <see cref="DateTimeOffset.Now"/>.</param>
+      public DateOnly RecentDateOnly(int days = 1, DateOnly? refDateOnly = null)
+      {
+         var dateTime = refDateOnly?.ToDateTime(default) ?? SystemClock();
+
+         var resultantDateTime = Recent(days, dateTime);
+         
+         return DateOnly.FromDateTime(resultantDateTime);
+      }
+
+      /// <summary>
+      /// Get a random <see cref="TimeOnly"/> between <paramref name="start"/> and <paramref name="end"/>.
+      /// </summary>
+      /// <param name="start">Start time</param>
+      /// <param name="end">End time</param>
+      /// <param name="dateTimeKind">Representation of DateTime. Default is <seealso cref="DateTimeKind.Local"/></param>
+      public TimeOnly BetweenTimeOnly(TimeOnly start, TimeOnly end, DateTimeKind dateTimeKind = DateTimeKind.Local)
+      {
+         var minTicks = Math.Min(start.Ticks, end.Ticks);
+         var maxTicks = Math.Max(start.Ticks, end.Ticks);
+
+         var totalTimeSpanTicks = maxTicks - minTicks;
+
+         var partTimeSpan = RandomTimeSpanFromTicks(totalTimeSpanTicks);
+
+         var resultantDate = new DateTime(minTicks, dateTimeKind) + partTimeSpan;
+
+         return TimeOnly.FromDateTime(resultantDate);
+      }
+
+      /// <summary>
+      /// Get a <see cref="TimeOnly"/> that will happen soon.
+      /// </summary>
+      /// <param name="mins">Minutes no more than <paramref name="mins"/> ahead.</param>
+      /// <param name="refTimeOnly">The Time to start calculations. Default is the only time from <see cref="DateTime.Now"/>.</param>
+      public TimeOnly SoonTimeOnly(int mins = 1, TimeOnly? refTimeOnly = null)
+      {
+         var timeOnly = refTimeOnly ?? TimeOnly.FromDateTime(DateTime.Now);
+
+         var dateTime = DateTime.Now.Date + timeOnly.ToTimeSpan();
+         
+         var dtTimeSoon = Between(dateTime, dateTime.AddMinutes(mins));
+         
+         return TimeOnly.FromDateTime(dtTimeSoon);
+      }
+
+      /// <summary>
+      /// Get a random <see cref="TimeOnly"/> within the last few Minutes.
+      /// </summary>
+      /// <param name="mins">Minutes <paramref name="mins"/> of the day to go back.</param>
+      /// <param name="refTimeOnly">The Time to start calculations. Default is the time from <see cref="DateTime.Now"/>.</param>
+      public TimeOnly RecentTimeOnly(int mins = 1, TimeOnly? refTimeOnly = null)
+      {
+         var maxDate = SystemClock();
+
+         var minDate = maxDate.AddMinutes(-mins);
+
+         var totalTimeSpanTicks = (maxDate - minDate).Ticks;
+
+         var partTimeSpan = RandomTimeSpanFromTicks(totalTimeSpanTicks);
+         
+         var pastTimeCal = maxDate - partTimeSpan;
+         
+         return TimeOnly.FromDateTime(pastTimeCal);
+      }
+#endif
    }
 }

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
    <PropertyGroup>
-      <LangVersion>9.0</LangVersion>
+      <LangVersion>10.0</LangVersion>
    </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Added Support to below methods for DateOnly and TimeOnly

      - `PastDateOnly` - Make defaults consistent with Past() DateTime
      - `SoonDateOnly` - Make defaults consistent with Soon() DateTime
      - `FutureDateOnly` - Make defaults consistent with Future() DateTime
      - `BetweenDateOnly` - Make defaults consistent with Between() DateTime
      - `RecentDateOnly` - Make defaults consistent with Recent() DateTime
      - `RecentTimeOnly` - Some time in the last 15 minutes
      - `SoonTimeOnly` - Some time in the next 15 minutes
      - `BetweenTimeOnly` - Some TimeOnly Between Start and End; always in a clockwise direction

- Added unit tests for each functionality
- Fixed ramifications of introduction of .NET 6 & C#10, those are
      - Fixed ambiguity between `DistinctBy()` from MoreLinq and System.Linq. `DictinctBy()` is newly introduced to Linq in C#10
      - Added `if !NET6_0` to not run one locale unit test for .NET 6, it is failing in .NET 6